### PR TITLE
Add sample Spring project with GitOps resources

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build and test
+        run: mvn -B verify
+      - name: Run OWASP ZAP Baseline DAST
+        uses: zaproxy/action-baseline@v0.9.0
+        with:
+          target: 'http://example.com'

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# spring-api-service
+# Demo Spring API Service
+
+This repository contains a simple Spring Boot application with an example CI pipeline including SAST and DAST steps. It also demonstrates contract testing with Pact, API testing with REST Assured, mocking with WireMock and basic GitOps resources using Helm and Kustomize for dev, stage and prod environments.
+
+## Building
+
+```bash
+mvn verify
+```
+
+## Helm Chart
+
+The `helm/` directory contains a basic Helm chart. Kustomize overlays for dev, stage and prod live under `kustomize/overlays`.

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: demo
+version: 0.1.0
+appVersion: 0.0.1

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+        - name: demo
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          ports:
+            - containerPort: 8080

--- a/helm/chart/templates/service.yaml
+++ b/helm/chart/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+spec:
+  selector:
+    app: demo
+  ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: 8080

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,0 +1,6 @@
+replicaCount: 1
+image:
+  repository: demo
+  tag: latest
+service:
+  port: 80

--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+        - name: demo
+          image: demo:latest
+          ports:
+            - containerPort: 8080

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kustomize/base/service.yaml
+++ b/kustomize/base/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+spec:
+  selector:
+    app: demo
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/kustomize/overlays/dev/kustomization.yaml
+++ b/kustomize/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../base
+namePrefix: dev-
+patchesStrategicMerge:
+  - replica.yaml

--- a/kustomize/overlays/dev/replica.yaml
+++ b/kustomize/overlays/dev/replica.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: 1

--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../base
+namePrefix: prod-
+patchesStrategicMerge:
+  - replica.yaml

--- a/kustomize/overlays/prod/replica.yaml
+++ b/kustomize/overlays/prod/replica.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: 3

--- a/kustomize/overlays/stage/kustomization.yaml
+++ b/kustomize/overlays/stage/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../base
+namePrefix: stage-
+patchesStrategicMerge:
+  - replica.yaml

--- a/kustomize/overlays/stage/replica.yaml
+++ b/kustomize/overlays/stage/replica.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: 2

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>demo</name>
+    <description>Demo project for end-to-end pipeline</description>
+
+    <properties>
+        <java.version>11</java.version>
+        <spring.boot.version>2.7.5</spring.boot.version>
+        <pact.version>4.3.6</pact.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>au.com.dius.pact.consumer</groupId>
+            <artifactId>junit5</artifactId>
+            <version>${pact.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <!-- SAST example with SpotBugs -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.7.3.0</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/demo/Application.java
+++ b/src/main/java/com/example/demo/Application.java
@@ -1,0 +1,20 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+@RestController
+public class Application {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello, World";
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=0

--- a/src/test/java/com/example/demo/ApplicationTest.java
+++ b/src/test/java/com/example/demo/ApplicationTest.java
@@ -1,0 +1,23 @@
+package com.example.demo;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ApplicationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void helloEndpoint() {
+        RestAssured.given().port(port)
+                .when().get("/hello")
+                .then().statusCode(200)
+                .body(equalTo("Hello, World"));
+    }
+}

--- a/src/test/java/com/example/demo/HelloConsumerPactTest.java
+++ b/src/test/java/com/example/demo/HelloConsumerPactTest.java
@@ -1,0 +1,46 @@
+package com.example.demo;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.ConsumerPactTest;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@ExtendWith(PactConsumerTestExt.class)
+class HelloConsumerPactTest extends ConsumerPactTest {
+
+    @Override
+    protected RequestResponsePact createPact(PactDslWithProvider builder) {
+        return builder
+                .given("default state")
+                .uponReceiving("hello request")
+                .path("/hello")
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body("Hello, World")
+                .toPact();
+    }
+
+    @Override
+    protected String providerName() {
+        return "hello-provider";
+    }
+
+    @Override
+    protected String consumerName() {
+        return "hello-consumer";
+    }
+
+    @Override
+    protected void runTest(MockServer mockServer) {
+        RestAssured.given().baseUri(mockServer.getUrl())
+                .when().get("/hello")
+                .then().statusCode(200)
+                .body(equalTo("Hello, World"));
+    }
+}

--- a/src/test/java/com/example/demo/WireMockExampleTest.java
+++ b/src/test/java/com/example/demo/WireMockExampleTest.java
@@ -1,0 +1,34 @@
+package com.example.demo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+class WireMockExampleTest {
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setup() {
+        wireMockServer = new WireMockServer();
+        wireMockServer.start();
+        configureFor("localhost", wireMockServer.port());
+        stubFor(get(urlEqualTo("/hello")).willReturn(aResponse().withBody("Hello, World")));
+    }
+
+    @AfterEach
+    void teardown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void sampleWireMock() {
+        given().baseUri("http://localhost:" + wireMockServer.port())
+                .when().get("/hello")
+                .then().statusCode(200).body(equalTo("Hello, World"));
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold simple Spring Boot service with `/hello` endpoint
- add REST Assured, Pact, and WireMock tests
- configure SpotBugs for SAST and OWASP ZAP baseline for DAST in GitHub Actions
- provide Helm chart and Kustomize overlays for dev, stage, and prod

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d12c1b688324aee65107340aa431